### PR TITLE
Security issues, bumping versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"       : "dirty-json-cli",
-  "version"    : "1.0.1",
+  "version"    : "1.0.2",
   "description": "format dirty json via command line",
   "main"       : "index.js",
   "scripts"    : {
@@ -20,6 +20,6 @@
     "dirty-json": "./index.js"
   },
   "dependencies": {
-    "dirty-json": "0.5.0"
+    "dirty-json": "^0.5.2"
   }
 }


### PR DESCRIPTION
Hello,

There's a REDOS regular expression vulnerability in version 0.5.0 of `dirty-json`. I'm pretty sure I've fixed it. I've updated the `package.json` here to use the fixed version (and any other minor release).

Thanks,
Ryan